### PR TITLE
Adds Containerizing option to users

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+# Install system dependencies for geopandas, pyproj, osmnx, etc.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	build-essential \
+	python3-dev \
+	python3-pip \
+	fonts-dejavu-core \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Set workdir
+WORKDIR /app
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code and resources
+COPY create_map_poster.py ./
+COPY fonts ./fonts
+COPY themes ./themes
+
+# Create posters output directory
+RUN mkdir -p posters
+
+# Default command
+ENTRYPOINT ["python", "create_map_poster.py"]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,44 @@ Posters are saved to `posters/` directory with format:
 {city}_{theme}_{YYYYMMDD_HHMMSS}.png
 ```
 
+
+## Using the Containerfile
+
+You can run the City Map Poster Generator in a containerized environment for maximum reproducibility and zero local setup.
+
+### Why `Containerfile` instead of `Dockerfile`?
+
+The file is named `Containerfile` to follow the [Open Container Initiative (OCI)](https://opencontainers.org/) recommendations and to signal compatibility with any OCI-compliant container runtime (not just Docker). Most modern tools (Docker, Podman, Buildah, etc.) recognize both `Dockerfile` and `Containerfile`.
+
+### Build the container image
+
+```bash
+# Using Docker
+docker build -t map-to-poster . -f Containerfile
+
+# Using Podman (rootless, recommended for Linux)
+podman build -t map-to-poster . -f Containerfile
+```
+
+### Run the generator in a container (examples for docker)
+
+
+```bash
+# List available themes
+docker run --rm map-to-poster --list-themes
+
+# Example: Generate a poster for Paris
+docker run --rm \
+    -v "$PWD/posters:/app/posters:Z" \
+    map-to-poster \
+    --city "Paris" \
+    --country "France" \
+    --distance 8000 \
+    --theme pastel_dream
+```
+
+Mount the `posters/` directory as a volume to access generated images on your host.
+
 ## Adding Custom Themes
 
 Create a JSON file in `themes/` directory:


### PR DESCRIPTION
Wow, amazing tool, found it on Hackernews :tada: 

---

This pull request adds support for containerized execution of the City Map Poster Generator, making it easier to run the application in a reproducible environment without local setup. The main changes include the addition of a `Containerfile` for building a container image and updates to the documentation to explain how to use the containerized workflow.

Containerization support:

* Added a `Containerfile` to define a reproducible Python 3.11-based container image, including installation of all system and Python dependencies, copying source code and resources, and setting up the default entrypoint.

Documentation updates:

* Updated `README.md` with detailed instructions for building and running the application using the new `Containerfile`, including rationale for the filename, build/run commands for Docker and Podman, and guidance on mounting the output directory.