### PR TITLE
feat: add --quality presets and --dpi flag for png output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cache/*
 env/
 .env/
+.DS_Store


### PR DESCRIPTION
Rebuilt on current \`main\` (the original figsize-based presets conflicted with the later \`--width\`/\`--height\` flags and their 20-inch cap).

Adds DPI-only quality control that layers on \`--width\`/\`--height\`:

- \`--quality\` / \`-q\`: \`low\` (150), \`standard\` (300, default), \`high\` (400), \`ultra\` (600)
- \`--dpi N\`: explicit DPI; mutually exclusive with \`--quality\`
- Prints the effective output size (\`inches @ DPI (~px)\`) after the width/height clamp
- DPI is applied to png only, matching existing svg/pdf handling
- README flag table updated; cases added to \`test/all_variations.sh\`

Addresses review comments: \`low\` preset for quick test renders (@Nudin), presets no longer exceed the dimension cap and \`--dpi\` is available for granular control with \`-W\`/\`-H\` (@necromeo).

Verified: flake8 + mypy clean (same invocation as \`pr-checks.yml\`); real renders checked with \`sips\`: \`-q low\` at 12x16 in -> ~1800x2400 px, \`--dpi 600 -W 22\` clamps to 20 in -> ~12000 px wide, \`-q ultra -f svg\` renders without applying DPI.