### PR TITLE
Add city font size option as CLI parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ python create_map_poster.py --city <city> --country <country> [options]
 | `--country` | `-C` | Country name | required |
 | `--theme` | `-t` | Theme name | feature_based |
 | `--distance` | `-d` | Map radius in meters | 29000 |
+| `--city-font-size` | | Font size for city name | 60 |
 | `--list-themes` | | List all available themes | |
 
 ### Examples

--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -213,7 +213,7 @@ def get_coordinates(city, country):
     else:
         raise ValueError(f"Could not find coordinates for {city}, {country}")
 
-def create_poster(city, country, point, dist, output_file):
+def create_poster(city, country, point, dist, output_file, city_font_size=60):
     print(f"\nGenerating map for {city}, {country}...")
     
     # Progress bar for data fetching
@@ -275,13 +275,13 @@ def create_poster(city, country, point, dist, output_file):
     
     # 4. Typography using Roboto font
     if FONTS:
-        font_main = FontProperties(fname=FONTS['bold'], size=60)
+        font_main = FontProperties(fname=FONTS['bold'], size=city_font_size)
         font_top = FontProperties(fname=FONTS['bold'], size=40)
         font_sub = FontProperties(fname=FONTS['light'], size=22)
         font_coords = FontProperties(fname=FONTS['regular'], size=14)
     else:
         # Fallback to system fonts
-        font_main = FontProperties(family='monospace', weight='bold', size=60)
+        font_main = FontProperties(family='monospace', weight='bold', size=city_font_size)
         font_top = FontProperties(family='monospace', weight='bold', size=40)
         font_sub = FontProperties(family='monospace', weight='normal', size=22)
         font_coords = FontProperties(family='monospace', size=14)
@@ -420,6 +420,7 @@ Examples:
     parser.add_argument('--country', '-C', type=str, help='Country name')
     parser.add_argument('--theme', '-t', type=str, default='feature_based', help='Theme name (default: feature_based)')
     parser.add_argument('--distance', '-d', type=int, default=29000, help='Map radius in meters (default: 29000)')
+    parser.add_argument('--city-font-size', type=int, default=60, help='Font size for city name (default: 60)')
     parser.add_argument('--list-themes', action='store_true', help='List all available themes')
     
     args = parser.parse_args()
@@ -458,7 +459,7 @@ Examples:
     try:
         coords = get_coordinates(args.city, args.country)
         output_file = generate_output_filename(args.city, args.theme)
-        create_poster(args.city, args.country, coords, args.distance, output_file)
+        create_poster(args.city, args.country, coords, args.distance, output_file, args.city_font_size)
         
         print("\n" + "=" * 50)
         print("✓ Poster generation complete!")


### PR DESCRIPTION
When the city name is long, it is truncated in the generated poster because font size is a constant. This pull request adds a new option to customize the font size of the city name on the generated map poster. The default font size remains 60, but users can now specify a different size via a command-line argument.

**Feature: Customizable city name font size**
- Added a `--city-font-size` command-line argument to allow users to set the font size for the city name on the poster, with a default of 60. (`create_map_poster.py`, `README.md`) [[1]](diffhunk://#diff-ef6a527be8849be0eab05712aaed7103ecd5a0530ce62fea2a24a44430c51313R423) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43)
- Updated the `create_poster` function to accept a `city_font_size` parameter and use it when rendering the city name, both for custom and fallback fonts. (`create_map_poster.py`) [[1]](diffhunk://#diff-ef6a527be8849be0eab05712aaed7103ecd5a0530ce62fea2a24a44430c51313L216-R216) [[2]](diffhunk://#diff-ef6a527be8849be0eab05712aaed7103ecd5a0530ce62fea2a24a44430c51313L278-R284)
- Modified the script's main execution flow to pass the `city_font_size` argument to `create_poster`. (`create_map_poster.py`)

**Documentation**
- Updated the usage table in `README.md` to include the new `--city-font-size` option. (`README.md`)