### PR TITLE
Fix/draw roads on top of parks

### DIFF
--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -417,9 +417,25 @@ def create_poster(city, country, point, dist, output_file, output_format, width=
     # 3. Plot Layers
     # Layer 1: Polygons (filter to only plot polygon/multipolygon geometries, not points)
     if water is not None and not water.empty:
-        water.plot(ax=ax, facecolor=THEME['water'], edgecolor='none', zorder=0)
+         # Filter to only polygon/multipolygon geometries to avoid point features showing as dots
+        water_polys = water[water.geometry.type.isin(['Polygon', 'MultiPolygon'])]
+        if not water_polys.empty:
+            # Project water features in the same CRS as the graph
+            try:
+                water_polys = ox.projection.project_gdf(water_polys)
+            except Exception:
+                water_polys = water_polys.to_crs(G_proj.graph['crs'])
+            water_polys.plot(ax=ax, facecolor=THEME['water'], edgecolor='none', zorder=0)
     if parks is not None and not parks.empty:
-        parks.plot(ax=ax, facecolor=THEME['parks'], edgecolor='none', zorder=0.5)
+         # Filter to only polygon/multipolygon geometries to avoid point features showing as dots
+        parks_polys = parks[parks.geometry.type.isin(['Polygon', 'MultiPolygon'])]
+        if not parks_polys.empty:
+            # Project park features in the same CRS as the graph
+            try:
+                parks_polys = ox.projection.project_gdf(parks_polys)
+            except Exception:
+                parks_polys = parks_polys.to_crs(G_proj.graph['crs'])
+            parks_polys.plot(ax=ax, facecolor=THEME['parks'], edgecolor='none', zorder=0.5)
 
     
     # Layer 2: Roads with hierarchy coloring


### PR DESCRIPTION
So when I was using this script to create a poster of Vancouver, BC, Canada, I noticed that it seemed parklands covered up roads. In the photo below, there should be a section of highway that cuts through the park however it is missing:

<img width="460" height="585" alt="image" src="https://github.com/user-attachments/assets/9d6a8803-ddb3-443e-8e39-d6151ee992f7" />

I managed to fix this by ensuring the roads were on a higher Z layer than the parks and water. I also made it so an "unclassified" roads were not drawn (had their width set to 0) to make the map look a bit nicer.

Below is an example of what the generated posters look like:

<img width="3600" height="4800" alt="vancouver_midnight_blue_20260118_210038" src="https://github.com/user-attachments/assets/79137cba-3a40-4384-b41c-742572044029" />
