### PR TITLE
fixed map warping and allow variable poster dimensions

### DIFF
--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -385,7 +385,7 @@ def create_poster(city, country, point, dist, output_file, output_format, width=
     with tqdm(total=3, desc="Fetching map data", unit="step", bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt}') as pbar:
         # 1. Fetch Street Network
         pbar.set_description("Downloading street network")
-        compensated_dist = dist * (max(height, width) / min(height, width)) # To compensate for viewport crop
+        compensated_dist = dist * (max(height, width) / min(height, width))/4 # To compensate for viewport crop
         G = fetch_graph(point, compensated_dist)
         if G is None:
             raise RuntimeError("Failed to retrieve street network data.")


### PR DESCRIPTION
This PR fixes map warping caused by aspect ratio mismatches and adds support for variable poster dimensions.

Changes
1. Corrected map scaling logic to account for width vs height aspect ratio
2. Ensured the larger dimension always drives the bounding box expansion
3. Removed hard-coded assumptions around poster dimensions
4. Improved visual consistency across portrait and landscape posters

Reason
Previous non-square poster dimensions resulted in warped maps due to mismatch in fetched graph and plotted graph dimensions. This change guarantees consistent coverage regardless of poster aspect ratio.

Impact
1. No breaking changes
2. To compensate for the internal crop, the image is zoomed out further to prevent useful regions of the map from being excluded in poster. This introduced additonal area at the top and bottom to fill the spaces properly
3. Enables flexible poster sizing without visual artifacts