### PR TITLE
Increase Nominatim timeout to 10 seconds

### DIFF
--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -200,7 +200,7 @@ def get_coordinates(city, country):
     Includes rate limiting to be respectful to the geocoding service.
     """
     print("Looking up coordinates...")
-    geolocator = Nominatim(user_agent="city_map_poster")
+    geolocator = Nominatim(user_agent="city_map_poster", timeout=10)
     
     # Add a small delay to respect Nominatim's usage policy
     time.sleep(1)


### PR DESCRIPTION
Increased timeout for coordinates lookup from the default 1 second to a more generous 10 seconds.

When trying this on my machine I would get the error
`✗ Error: HTTPSConnectionPool(host='nominatim.openstreetmap.org', port=443): Max retries exceeded with url: /search?q=New+York%2C+USA&format=json&limit=1 (Caused by ReadTimeoutError("HTTPSConnectionPool(host='nominatim.openstreetmap.org', port=443): Read timed out. (read timeout=1)")) Traceback (most recent call last):`

adding a 10 second timeout fixed this