### PR TITLE
Support custom place labels with numbered markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ python create_map_poster.py --city <city> --country <country> [options]
 | `--theme` | `-t` | Theme name | feature_based |
 | `--distance` | `-d` | Map radius in meters | 29000 |
 | `--list-themes` | | List all available themes | |
+| `--label-places` | | Comma-separated list of place names to label on the map | |
 
 ### Examples
 


### PR DESCRIPTION
Currently, the poster only displays the road network and city outline. Many users want to highlight specific places within a city, such as:

- Neighborhoods they lived in
- Important landmarks
- Tourist areas
- Personal points of interest

This PR adds support for labeling user-specified places on the generated map poster using a new `--label-places` CLI option.

Users can now provide a list of place names (e.g. neighborhoods, landmarks, or areas within a city), which are geocoded and displayed on the map as numbered markers, with a corresponding legend rendered in the map layout.

---
### Example
`python create_map_poster.py -c "Tokyo" -C "Japan" -t japanese_ink -d 15000 --label-places "Shinjuku, Shibuya, Akihabara, Ginza, Koto, Tokyo Disneyland"`

![img](https://github.com/user-attachments/assets/487e282c-06cf-48b0-bb55-6c41056da79c)