### PR TITLE
Added Docker support with docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Exclude from Docker build context
+posters/
+cache/
+old/
+*.pyc
+__pycache__/
+.git/
+.gitignore
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies required by geopandas/osmnx
+RUN apt-get update && apt-get install -y \
+    gdal-bin \
+    libgdal-dev \
+    libspatialindex-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy everything (.dockerignore excludes posters, cache, git, etc.)
+COPY . .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Create excluded directories for use in docker-only context
+RUN mkdir -p posters cache

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Generate beautiful, minimalist map posters for any city in the world.
 
 ## Examples
 
-
 | Country      | City           | Theme           | Poster |
 |:------------:|:--------------:|:---------------:|:------:|
 | USA          | San Francisco  | sunset          | <img src="posters/san_francisco_sunset_20260118_144726.png" width="250"> |
@@ -25,6 +24,16 @@ Generate beautiful, minimalist map posters for any city in the world.
 ```bash
 pip install -r requirements.txt
 ```
+
+### Docker
+
+Run `docker compose up -d` to build and start the container.
+
+Enter the container shell with `docker compose exec maptoposter bash` to run python commands.
+
+Stop the container with `docker compose down`.
+
+Note: If requirements.txt changes, you'll need to rebuild the docker image with `docker compose build`.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  maptoposter:
+    build: .
+    # Mounts entire project so code changes reflect immediately
+    volumes:
+      - .:/app
+    # Keep container running
+    command: sleep infinity


### PR DESCRIPTION
For people that don't want to install python, I've added support for Docker via docker-compose.
Brief instructions are in the Readme.

A Dockerfile builds an image with required dependencies.
The docker-compose file uses this image + mounts the root directory as a volume so users can change files for local development.

Note: The Dockerfile also lets you build a fully self-contained Docker image to share on platforms like dockerhub.