### PR TITLE
Dockerize map poster generator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__
+*.pyc
+.git
+.gitignore
+.env
+venv
+posters/*
+cache/*
+.cache
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "create_map_poster.py"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ Generate beautiful, minimalist map posters for any city in the world.
 pip install -r requirements.txt
 ```
 
+## Running with Docker
+
+You can run the application without installing Python by using Docker.
+
+1.  **Build the image:**
+    ```bash
+    docker compose build
+    ```
+
+2.  **Run the generator:**
+    ```bash
+    docker compose run --rm map-poster --city "London" --country "UK"
+    ```
+
+    All arguments supported by the script can be passed to the command.
+
+    The generated posters will appear in the `posters/` directory on your host machine.
+    Map data is cached in the `cache/` directory to speed up subsequent runs.
+
 ## Usage
 
 ```bash

--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -35,10 +35,6 @@ THEMES_DIR = "themes"
 FONTS_DIR = "fonts"
 POSTERS_DIR = "posters"
 
-CACHE_DIR = ".cache"
-
-class CacheError(Exception):
-    pass
 
 
 def _cache_path(key: str) -> str:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  map-poster:
+    build: .
+    image: city-map-poster
+    volumes:
+      - ./posters:/app/posters
+      - ./cache:/app/cache
+      - ./themes:/app/themes
+      - ./fonts:/app/fonts
+    environment:
+      - CACHE_DIR=/app/cache


### PR DESCRIPTION
This PR dockerizes the city map poster generator. 
It adds a Dockerfile and docker-compose.yml to allow running the application without installing Python locally. 
It also fixes a bug in the python script where the CACHE_DIR variable was hardcoded, preventing configuration via environment variables (which is used in the Docker setup). 
Instructions for using Docker are added to the README.