### PR TITLE
Enable OSMnx caching

### DIFF
--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -42,6 +42,10 @@ CACHE_DIR_PATH = os.environ.get("CACHE_DIR", "cache")
 CACHE_DIR = Path(CACHE_DIR_PATH)
 CACHE_DIR.mkdir(exist_ok=True)
 
+# Configure OSMnx
+ox.settings.use_cache = True
+ox.settings.log_console = False
+
 THEMES_DIR = "themes"
 FONTS_DIR = "fonts"
 POSTERS_DIR = "posters"


### PR DESCRIPTION
What
- enable OSMnx cache to speed repeat fetches

Why
- reduce redundant network calls when generating posters using identical `-d` values