### PR TITLE
feature: custom output directory

### DIFF
--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -980,7 +980,7 @@ Examples:
         print_examples()
         sys.exit(1)
 
-    # set putput path
+    # set output path
     if args.output_directory:
         POSTERS_DIR = os.path.expanduser(args.output_directory)
 


### PR DESCRIPTION
This PR adds an argument `--output-directory` to make the poster output path configurable.