### PR TITLE
feat(render): add --line-scale option for road line thickness

### DIFF
--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -493,6 +493,7 @@ def create_poster(
     display_city=None,
     display_country=None,
     fonts=None,
+    line_scale=1.0,
 ):
     """
     Generate a complete map poster with roads, water, parks, and typography.
@@ -594,7 +595,7 @@ def create_poster(
     # Layer 2: Roads with hierarchy coloring
     print("Applying road hierarchy colors...")
     edge_colors = get_edge_colors_by_type(g_proj)
-    edge_widths = get_edge_widths_by_type(g_proj)
+    edge_widths = [w * line_scale for w in get_edge_widths_by_type(g_proj)]
 
     # Determine cropping limits to maintain the poster aspect ratio
     crop_xlim, crop_ylim = get_crop_limits(g_proj, point, fig, compensated_dist)
@@ -949,6 +950,13 @@ Examples:
         help='Google Fonts family name (e.g., "Noto Sans JP", "Open Sans"). If not specified, uses local Roboto fonts.',
     )
     parser.add_argument(
+        "--line-scale",
+        "-ls",
+        type=float,
+        default=1.0,
+        help="Multiplier for road/structure line thickness (default: 1.0, try 2-4 for small areas)",
+    )
+    parser.add_argument(
         "--format",
         "-f",
         default="png",
@@ -1037,6 +1045,7 @@ Examples:
                 display_city=args.display_city,
                 display_country=args.display_country,
                 fonts=custom_fonts,
+                line_scale=args.line_scale,
             )
 
         print("\n" + "=" * 50)


### PR DESCRIPTION
## Problem

When generating posters for small areas (e.g. individual districts or neighborhoods), the default road line thickness produces very thin, hard-to-see roads because the zoom level makes the area roads too fine.

## Solution

Add a `--line-scale` option that applies a multiplier to road line thickness. This allows users to increase thickness when rendering small areas where the defaults are insufficient.

**Usage:**
```
uv run ./create_map_poster.py --city "Stadtwald" --country "Marburg" -lat 50.7906111111 -long 8.73826111111 -d 1650 --line-scale 5
```

## Before / After 

### Stadtwald: a small neighbourhood
--line-scale 1 (Default) vs --line-scale 5 

  | Before | After |
  |--------|-------|
  | <img width="400" alt="stadtwald-before" src="https://github.com/user-attachments/assets/c23d2791-4b21-499c-a55a-2209871d207a" /> | <img width="400" alt="stadtwald-after" src="https://github.com/user-attachments/assets/02a32dbf-e94c-4239-8146-6facfc072781" /> |

With default line thickness, roads in small-area maps like Stadtwald or neighbourhoods are very thin and hard to see. With an increased `--line-scale` value, roads become clearly visible.