### PR TITLE
Add simple waterway=river to map

### DIFF
--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -545,6 +545,13 @@ def create_poster(
             tags={"natural": ["water", "bay", "strait"], "waterway": "riverbank"},
             name="water",
         )
+
+        # Get rivers that are only mapped as single line, common in many cities with rivers that aren't too wide 
+        try:
+            rivers = ox.features_from_point(point, tags={'waterway': 'river'}, dist=dist)
+        except:
+            rivers = None
+        
         pbar.update(1)
 
         # 3. Fetch Parks
@@ -557,6 +564,12 @@ def create_poster(
         )
         pbar.update(1)
 
+    # Get rivers that are only mapped as part of the 
+    try:
+        rivers= ox.features_from_point(point, tags={'waterway': 'river'}, dist=dist)
+    except:
+        rivers = None
+    
     print("✓ All data retrieved successfully!")
 
     # 2. Setup Plot
@@ -591,7 +604,12 @@ def create_poster(
             except Exception:
                 parks_polys = parks_polys.to_crs(g_proj.graph['crs'])
             parks_polys.plot(ax=ax, facecolor=THEME['parks'], edgecolor='none', zorder=0.8)
-    # Layer 2: Roads with hierarchy coloring
+    # Layer 2: Small rivers and roads with hierarchy coloring
+
+    if rivers is not None and not rivers.empty:
+        rivers = ox.projection.project_gdf(rivers)
+        rivers.plot(ax=ax, color=THEME['water'], linewidth=1.5, zorder=0.5)
+    
     print("Applying road hierarchy colors...")
     edge_colors = get_edge_colors_by_type(g_proj)
     edge_widths = get_edge_widths_by_type(g_proj)

--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -563,12 +563,6 @@ def create_poster(
             name="parks",
         )
         pbar.update(1)
-
-    # Get rivers that are only mapped as part of the 
-    try:
-        rivers= ox.features_from_point(point, tags={'waterway': 'river'}, dist=dist)
-    except:
-        rivers = None
     
     print("✓ All data retrieved successfully!")
 


### PR DESCRIPTION
Many rivers that flow through cities and towns aren't mapped as polygons when they aren't too wide. So far those are missing, this adds them in. See before after:

 
<img width="3630" height="4830" alt="agua_de_oro_comaps_20260415_123502" src="https://github.com/user-attachments/assets/52cb32ea-c03d-494b-950a-1188b2883b05" />
<img width="3630" height="4830" alt="agua_de_oro_comaps_20260415_120932" src="https://github.com/user-attachments/assets/85d4188a-8455-435d-82eb-ee5a7711538e" />
