### PR TITLE
Add CoMaps inspired theme

### DIFF
--- a/themes/comaps.json
+++ b/themes/comaps.json
@@ -1,0 +1,15 @@
+{
+  "name": "CoMaps",
+  "description": "Creates maps that look like slightly simplified screenshot of the mobile app CoMaps (https://comaps.app)",
+  "bg": "#F5E8D6",
+  "text": "#000000",
+  "gradient_color": "#F5F0E8",
+  "water": "#89CDDC",
+  "parks": "#D5DB8F",
+  "road_motorway": "#F08800",
+  "road_primary": "#F5B74E",
+  "road_secondary": "#FFCE5A",
+  "road_tertiary": "#FFFFFF",
+  "road_residential": "#FFFEFE",
+  "road_default": "#FFFFFF"
+}


### PR DESCRIPTION
Creates posters that look like the maps that [CoMaps](https://www.comaps.app/) uses in its apps.
<img width="3630" height="4830" alt="cordoba_comaps_20260415_122747" src="https://github.com/user-attachments/assets/6776a138-9a64-4813-8c93-4dd0bcb44e1b" />

<img width="2254" height="3000" alt="paris_comaps_20260415_112924" src="https://github.com/user-attachments/assets/dd5a6db6-e75a-4ac2-9e01-f1db8ef7c122" />
