### PR TITLE
feat: add --no-text flag to conditionally disable text overlays on map posters

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ python create_map_poster.py --city <city> --country <country> [options]
 | **OPTIONAL:** `--country-label` | | Override country text displayed on poster | |
 | **OPTIONAL:** `--theme` | `-t` | Theme name | terracotta |
 | **OPTIONAL:** `--distance` | `-d` | Map radius in meters | 18000 |
+| **OPTIONAL:** `--no-text` | | Hide all text overlays (city, country, coordinates, attribution) | false |
 | **OPTIONAL:** `--list-themes` | | List all available themes | |
 | **OPTIONAL:** `--all-themes` | | Generate posters for all available themes | |
 | **OPTIONAL:** `--width` | `-W` | Image width in inches | 12 (max: 20) |
@@ -127,6 +128,9 @@ python create_map_poster.py -c "Paris" -C "France"
 
 # With custom theme and distance
 python create_map_poster.py -c "New York" -C "USA" -t noir -d 12000
+
+# Map-only poster (no title/subtitle/coordinates/attribution text)
+python create_map_poster.py -c "Tokyo" -C "Japan" -t terracotta --no-text
 ```
 
 #### Multilingual Examples (Non-Latin Scripts)

--- a/create_map_poster.py
+++ b/create_map_poster.py
@@ -493,6 +493,7 @@ def create_poster(
     display_city=None,
     display_country=None,
     fonts=None,
+    show_text=True,
 ):
     """
     Generate a complete map poster with roads, water, parks, and typography.
@@ -511,6 +512,7 @@ def create_poster(
         height: Poster height in inches (default: 16)
         country_label: Optional override for country text on poster
         _name_label: Optional override for city name (unused, reserved for future use)
+        show_text: Whether to render text overlays (city/country/coords/attribution)
 
     Raises:
         RuntimeError: If street network data cannot be retrieved
@@ -615,142 +617,143 @@ def create_poster(
     create_gradient_fade(ax, THEME['gradient_color'], location='bottom', zorder=10)
     create_gradient_fade(ax, THEME['gradient_color'], location='top', zorder=10)
 
-    # Calculate scale factor based on smaller dimension (reference 12 inches)
-    # This ensures text scales properly for both portrait and landscape orientations
-    scale_factor = min(height, width) / 12.0
+    if show_text:
+        # Calculate scale factor based on smaller dimension (reference 12 inches)
+        # This ensures text scales properly for both portrait and landscape orientations
+        scale_factor = min(height, width) / 12.0
 
-    # Base font sizes (at 12 inches width)
-    base_main = 60
-    base_sub = 22
-    base_coords = 14
-    base_attr = 8
+        # Base font sizes (at 12 inches width)
+        base_main = 60
+        base_sub = 22
+        base_coords = 14
+        base_attr = 8
 
-    # 4. Typography - use custom fonts if provided, otherwise use default FONTS
-    active_fonts = fonts or FONTS
-    if active_fonts:
-        # font_main is calculated dynamically later based on length
-        font_sub = FontProperties(
-            fname=active_fonts["light"], size=base_sub * scale_factor
+        # 4. Typography - use custom fonts if provided, otherwise use default FONTS
+        active_fonts = fonts or FONTS
+        if active_fonts:
+            # font_main is calculated dynamically later based on length
+            font_sub = FontProperties(
+                fname=active_fonts["light"], size=base_sub * scale_factor
+            )
+            font_coords = FontProperties(
+                fname=active_fonts["regular"], size=base_coords * scale_factor
+            )
+            font_attr = FontProperties(
+                fname=active_fonts["light"], size=base_attr * scale_factor
+            )
+        else:
+            # Fallback to system fonts
+            font_sub = FontProperties(
+                family="monospace", weight="normal", size=base_sub * scale_factor
+            )
+            font_coords = FontProperties(
+                family="monospace", size=base_coords * scale_factor
+            )
+            font_attr = FontProperties(family="monospace", size=base_attr * scale_factor)
+
+        # Format city name based on script type
+        # Latin scripts: apply uppercase and letter spacing for aesthetic
+        # Non-Latin scripts (CJK, Thai, Arabic, etc.): no spacing, preserve case structure
+        if is_latin_script(display_city):
+            # Latin script: uppercase with letter spacing (e.g., "P  A  R  I  S")
+            spaced_city = "  ".join(list(display_city.upper()))
+        else:
+            # Non-Latin script: no spacing, no forced uppercase
+            # For scripts like Arabic, Thai, Japanese, etc.
+            spaced_city = display_city
+
+        # Dynamically adjust font size based on city name length to prevent truncation
+        # We use the already scaled "main" font size as the starting point.
+        base_adjusted_main = base_main * scale_factor
+        city_char_count = len(display_city)
+
+        # Heuristic: If length is > 10, start reducing.
+        if city_char_count > 10:
+            length_factor = 10 / city_char_count
+            adjusted_font_size = max(base_adjusted_main * length_factor, 10 * scale_factor)
+        else:
+            adjusted_font_size = base_adjusted_main
+
+        if active_fonts:
+            font_main_adjusted = FontProperties(
+                fname=active_fonts["bold"], size=adjusted_font_size
+            )
+        else:
+            font_main_adjusted = FontProperties(
+                family="monospace", weight="bold", size=adjusted_font_size
+            )
+
+        # --- BOTTOM TEXT ---
+        ax.text(
+            0.5,
+            0.14,
+            spaced_city,
+            transform=ax.transAxes,
+            color=THEME["text"],
+            ha="center",
+            fontproperties=font_main_adjusted,
+            zorder=11,
         )
-        font_coords = FontProperties(
-            fname=active_fonts["regular"], size=base_coords * scale_factor
-        )
-        font_attr = FontProperties(
-            fname=active_fonts["light"], size=base_attr * scale_factor
-        )
-    else:
-        # Fallback to system fonts
-        font_sub = FontProperties(
-            family="monospace", weight="normal", size=base_sub * scale_factor
-        )
-        font_coords = FontProperties(
-            family="monospace", size=base_coords * scale_factor
-        )
-        font_attr = FontProperties(family="monospace", size=base_attr * scale_factor)
 
-    # Format city name based on script type
-    # Latin scripts: apply uppercase and letter spacing for aesthetic
-    # Non-Latin scripts (CJK, Thai, Arabic, etc.): no spacing, preserve case structure
-    if is_latin_script(display_city):
-        # Latin script: uppercase with letter spacing (e.g., "P  A  R  I  S")
-        spaced_city = "  ".join(list(display_city.upper()))
-    else:
-        # Non-Latin script: no spacing, no forced uppercase
-        # For scripts like Arabic, Thai, Japanese, etc.
-        spaced_city = display_city
-
-    # Dynamically adjust font size based on city name length to prevent truncation
-    # We use the already scaled "main" font size as the starting point.
-    base_adjusted_main = base_main * scale_factor
-    city_char_count = len(display_city)
-
-    # Heuristic: If length is > 10, start reducing.
-    if city_char_count > 10:
-        length_factor = 10 / city_char_count
-        adjusted_font_size = max(base_adjusted_main * length_factor, 10 * scale_factor)
-    else:
-        adjusted_font_size = base_adjusted_main
-
-    if active_fonts:
-        font_main_adjusted = FontProperties(
-            fname=active_fonts["bold"], size=adjusted_font_size
-        )
-    else:
-        font_main_adjusted = FontProperties(
-            family="monospace", weight="bold", size=adjusted_font_size
+        ax.text(
+            0.5,
+            0.10,
+            display_country.upper(),
+            transform=ax.transAxes,
+            color=THEME["text"],
+            ha="center",
+            fontproperties=font_sub,
+            zorder=11,
         )
 
-    # --- BOTTOM TEXT ---
-    ax.text(
-        0.5,
-        0.14,
-        spaced_city,
-        transform=ax.transAxes,
-        color=THEME["text"],
-        ha="center",
-        fontproperties=font_main_adjusted,
-        zorder=11,
-    )
+        lat, lon = point
+        coords = (
+            f"{lat:.4f}° N / {lon:.4f}° E"
+            if lat >= 0
+            else f"{abs(lat):.4f}° S / {lon:.4f}° E"
+        )
+        if lon < 0:
+            coords = coords.replace("E", "W")
 
-    ax.text(
-        0.5,
-        0.10,
-        display_country.upper(),
-        transform=ax.transAxes,
-        color=THEME["text"],
-        ha="center",
-        fontproperties=font_sub,
-        zorder=11,
-    )
+        ax.text(
+            0.5,
+            0.07,
+            coords,
+            transform=ax.transAxes,
+            color=THEME["text"],
+            alpha=0.7,
+            ha="center",
+            fontproperties=font_coords,
+            zorder=11,
+        )
 
-    lat, lon = point
-    coords = (
-        f"{lat:.4f}° N / {lon:.4f}° E"
-        if lat >= 0
-        else f"{abs(lat):.4f}° S / {lon:.4f}° E"
-    )
-    if lon < 0:
-        coords = coords.replace("E", "W")
+        ax.plot(
+            [0.4, 0.6],
+            [0.125, 0.125],
+            transform=ax.transAxes,
+            color=THEME["text"],
+            linewidth=1 * scale_factor,
+            zorder=11,
+        )
 
-    ax.text(
-        0.5,
-        0.07,
-        coords,
-        transform=ax.transAxes,
-        color=THEME["text"],
-        alpha=0.7,
-        ha="center",
-        fontproperties=font_coords,
-        zorder=11,
-    )
+        # --- ATTRIBUTION (bottom right) ---
+        if FONTS:
+            font_attr = FontProperties(fname=FONTS["light"], size=8)
+        else:
+            font_attr = FontProperties(family="monospace", size=8)
 
-    ax.plot(
-        [0.4, 0.6],
-        [0.125, 0.125],
-        transform=ax.transAxes,
-        color=THEME["text"],
-        linewidth=1 * scale_factor,
-        zorder=11,
-    )
-
-    # --- ATTRIBUTION (bottom right) ---
-    if FONTS:
-        font_attr = FontProperties(fname=FONTS["light"], size=8)
-    else:
-        font_attr = FontProperties(family="monospace", size=8)
-
-    ax.text(
-        0.98,
-        0.02,
-        "© OpenStreetMap contributors",
-        transform=ax.transAxes,
-        color=THEME["text"],
-        alpha=0.5,
-        ha="right",
-        va="bottom",
-        fontproperties=font_attr,
-        zorder=11,
-    )
+        ax.text(
+            0.98,
+            0.02,
+            "© OpenStreetMap contributors",
+            transform=ax.transAxes,
+            color=THEME["text"],
+            alpha=0.5,
+            ha="right",
+            va="bottom",
+            fontproperties=font_attr,
+            zorder=11,
+        )
 
     # 5. Save
     print(f"Saving to {output_file}...")
@@ -818,6 +821,7 @@ Options:
   --country-label   Override country text displayed on poster
   --theme, -t       Theme name (default: terracotta)
   --all-themes      Generate posters for all themes
+  --no-text         Hide all text overlays (city, country, coordinates, attribution)
   --distance, -d    Map radius in meters (default: 18000)
   --list-themes     List all available themes
 
@@ -906,6 +910,11 @@ Examples:
         dest="all_themes",
         action="store_true",
         help="Generate posters for all themes",
+    )
+    parser.add_argument(
+        "--no-text",
+        action="store_true",
+        help="Hide all text overlays (city, country, coordinates, attribution)",
     )
     parser.add_argument(
         "--distance",
@@ -1037,6 +1046,7 @@ Examples:
                 display_city=args.display_city,
                 display_country=args.display_country,
                 fonts=custom_fonts,
+                show_text=not args.no_text,
             )
 
         print("\n" + "=" * 50)

--- a/test/all_variations.sh
+++ b/test/all_variations.sh
@@ -50,6 +50,9 @@ uv run python3 create_map_poster.py -c "Bengaluru" -C "India" --display-city "Th
 echo "Overriding latitude and longitude (central Bengaluru)"
 uv run python3 create_map_poster.py -c "Bengaluru" -C "India" -lat 12.9716 -long 77.5946
 
+echo "Generating without text (--no-text)"
+uv run python3 create_map_poster.py -c "Bengaluru" -C "India" --no-text
+
 # 4. Multilingual Support (from i18n section)
 echo "--- Multilingual Support (i18n) ---"
 echo "Kannada (Native script)"


### PR DESCRIPTION
This PR introduces a new --no-text command-line argument that allows users to generate map posters without any embedded text overlays. By default, maps are generated with the city, country, coordinates, and attribution text, but in some scenarios (e.g., when users want to use the maps as clean backgrounds or apply custom text in post-processing), a completely textless variant is preferred.

Changes Made:
- Added a --no-text argument flag to create_map_poster.py.
- Updated make_poster logic to accept a new show_text boolean parameter (derived from not args.no_text).
- Wrapped the rendering logic for the main title, subtitle, coordinates, divider line, and attribution within a conditional if show_text: block.
- Updated the testing suite in test/all_variations.sh to include a validation step for the new --no-text flag.
- Added flag documentation to the script's help menu.

How to Test: Run the following command to generate a map without the text overlays:

```bash
uv run python3 create_map_poster.py -c "Bengaluru" -C "India" --no-text
```
Verify that the output poster does not contain the city name, country name, coordinates, divider line, or bottom-right attribution, but correctly outputs the map and border layout. Alternatively, you can run the test/all_variations.sh script to verify it fits nicely alongside existing tests.

This is the result example for Tokyo, Japan
![Uploading tokyo_neon_cyberpunk_20260417_104542.png…]()
