### PR TITLE
Include font_management in wheel py-modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,4 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-py-modules = ["create_map_poster"]
+py-modules = ["create_map_poster", "font_management"]


### PR DESCRIPTION
## Problem

Installing maptoposter as a package (e.g. `pip install git+https://github.com/originalankur/maptoposter.git`) produces a wheel that contains only `create_map_poster.py`. Importing it then fails immediately:

```
$ python -m create_map_poster --help
Traceback (most recent call last):
  ...
  File ".../site-packages/create_map_poster.py", line 24, in <module>
    from font_management import (
ModuleNotFoundError: No module named 'font_management'
```

`font_management.py` lives at the repo root next to `create_map_poster.py`, but `[tool.setuptools] py-modules` lists only `create_map_poster`, so the wheel never includes it. Running from a source checkout hides the bug (the sibling file resolves via cwd), which is why the CLI works in-repo but the installed package is broken.

## Fix

Add `font_management` to `py-modules` so both top-level modules ship in the wheel.

Verified locally on Windows/Python 3.13: `pip install` from this branch → `python -m create_map_poster --city "Galway" --country "Ireland" ...` renders a poster; installing from current `main` reproduces the `ModuleNotFoundError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
